### PR TITLE
Fix TypeScript cast in define:vars script (layout lang filter)

### DIFF
--- a/ui/src/layouts/Layout.astro
+++ b/ui/src/layouts/Layout.astro
@@ -83,7 +83,7 @@ const base = import.meta.env.BASE_URL;
     document.querySelectorAll("[data-sov-lang]").forEach(el => {
       const docLang = el.getAttribute("data-sov-lang");
       const show = lang === "en" ? docLang === "en" : docLang !== "en";
-      (el as HTMLElement).style.display = show ? "" : "none";
+      /** @type {HTMLElement} */ (el).style.display = show ? "" : "none";
     });
   }
 


### PR DESCRIPTION
(el as HTMLElement) is invalid JS; replaced with JSDoc cast. This was causing astro check to fail with ts(8016), blocking CI.

https://claude.ai/code/session_01BQEXr6ceS6USuJyuwmWGuZ